### PR TITLE
PCM Registers, Various APU Improvements, Correct Extra OAM Masking for CGB-C

### DIFF
--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -687,6 +687,16 @@ unsigned Memory::nontrivial_ff_read(unsigned const p, unsigned long const cc) {
 			return lcd_.cgbSpColorRead(ioamhram_[0x16A] & 0x3F, cc);
 
 		break;
+	case 0x76:
+		if (isCgb())
+			return psg_.pcm12Read(cc, isDoubleSpeed());
+
+		break;
+	case 0x77:
+		if (isCgb())
+			return psg_.pcm34Read(cc, isDoubleSpeed());
+
+		break;
 	default:
 		break;
 	}

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -689,12 +689,12 @@ unsigned Memory::nontrivial_ff_read(unsigned const p, unsigned long const cc) {
 		break;
 	case 0x76:
 		if (isCgb())
-			return psg_.pcm12Read(cc, isDoubleSpeed());
+			return psg_.isEnabled() ? psg_.pcm12Read(cc, isDoubleSpeed()) : 0;
 
 		break;
 	case 0x77:
 		if (isCgb())
-			return psg_.pcm34Read(cc, isDoubleSpeed());
+			return psg_.isEnabled() ? psg_.pcm34Read(cc, isDoubleSpeed()) : 0;
 
 		break;
 	default:

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -1381,7 +1381,7 @@ LoadRes Memory::loadROM(std::string const &romfile, unsigned const flags) {
 	agbFlag_ = flags & GB::LoadFlag::GBA_FLAG;
 	gbIsSgb_ = flags & GB::LoadFlag::SGB_MODE;
 
-	psg_.init(cart_.isCgb());
+	psg_.init(cart_.isCgb(), agbFlag_);
 	lcd_.reset(ioamhram_, cart_.vramdata(), cart_.isCgb(), agbFlag_);
 	interrupter_.setGameShark(std::string());
 
@@ -1406,7 +1406,7 @@ LoadRes Memory::loadROM(char const *romfiledata, unsigned romfilelength, unsigne
 	agbFlag_ = flags & GB::LoadFlag::GBA_FLAG;
 	gbIsSgb_ = flags & GB::LoadFlag::SGB_MODE;
 
-	psg_.init(cart_.isCgb());
+	psg_.init(cart_.isCgb(), agbFlag_);
 	lcd_.reset(ioamhram_, cart_.vramdata(), cart_.isCgb(), agbFlag_);
 
 	return LOADRES_OK;

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -203,7 +203,7 @@ public:
 			lastCartBusUpdate_ = cc;
 			return cartBus_;
 		}
-		if (cart_.isPocketCamera() && cart_.cameraIsActive(cc) && (p >= mm_sram_begin && p < mm_wram_begin)) {
+		if (cart_.isPocketCamera() && (p >= mm_sram_begin && p < mm_wram_begin) && cart_.cameraIsActive(cc)) {
 			return cart_.rmem(p >> 12)
 				? 0x00
 				: nontrivial_read(p, cc);

--- a/libgambatte/src/savestate.h
+++ b/libgambatte/src/savestate.h
@@ -152,6 +152,7 @@ struct SaveState {
 		struct Env {
 			unsigned long counter;
 			unsigned char volume;
+			unsigned char /*bool*/ clock;
 		};
 
 		struct LCounter {

--- a/libgambatte/src/sound.cpp
+++ b/libgambatte/src/sound.cpp
@@ -59,9 +59,11 @@ PSG::PSG()
 {
 }
 
-void PSG::init(bool cgb) {
-	ch1_.init(cgb);
+void PSG::init(bool cgb, bool agb) {
+	ch1_.init(cgb, agb);
+	ch2_.init(agb);
 	ch3_.init(cgb);
+	ch4_.init(cgb, agb);
 }
 
 void PSG::reset(bool ds) {

--- a/libgambatte/src/sound.cpp
+++ b/libgambatte/src/sound.cpp
@@ -230,8 +230,20 @@ unsigned PSG::getStatus() const {
 }
 
 std::size_t PSG::callbackCycleOffset(unsigned long const cpuCc, bool const doubleSpeed) {
+	unsigned long const cyclesOff = (cpuCc - lastUpdate_) >> (1 + doubleSpeed);
+	return bufferPos_ + cyclesOff;
+}
+
+unsigned char PSG::pcm12Read(unsigned long const cpuCc, bool const doubleSpeed) {
 	generateSamples(cpuCc, doubleSpeed);
-	return bufferPos_;
+	return ((ch2_.isActive() ? ch2_.getVolume() : 0) << 4)
+	| (ch1_.isActive() ? ch1_.getVolume() : 0);
+}
+
+unsigned char PSG::pcm34Read(unsigned long const cpuCc, bool const doubleSpeed) {
+	generateSamples(cpuCc, doubleSpeed);
+	return ((ch4_.isActive() ? ch4_.getVolume() : 0) << 4)
+	| (ch3_.isActive() ? ch3_.getVolume() : 0);
 }
 
 // the buffer and position are not saved, as they're set and flushed on each runfor() call

--- a/libgambatte/src/sound.cpp
+++ b/libgambatte/src/sound.cpp
@@ -231,7 +231,7 @@ unsigned PSG::getStatus() const {
 	     | ch4_.isActive() << 3;
 }
 
-std::size_t PSG::callbackCycleOffset(unsigned long const cpuCc, bool const doubleSpeed) {
+unsigned long PSG::callbackCycleOffset(unsigned long const cpuCc, bool const doubleSpeed) const {
 	unsigned long const cyclesOff = (cpuCc - lastUpdate_) >> (1 + doubleSpeed);
 	return bufferPos_ + cyclesOff;
 }

--- a/libgambatte/src/sound.h
+++ b/libgambatte/src/sound.h
@@ -75,6 +75,8 @@ public:
 	unsigned getStatus() const;
 
 	std::size_t callbackCycleOffset(unsigned long cycleCounter, bool doubleSpeed);
+	unsigned char pcm12Read(unsigned long cycleCounter, bool doubleSpeed);
+	unsigned char pcm34Read(unsigned long cycleCounter, bool doubleSpeed);
 
 	void setSpeedupFlags(unsigned flags) { speedupFlags_ = flags; }
 

--- a/libgambatte/src/sound.h
+++ b/libgambatte/src/sound.h
@@ -74,7 +74,7 @@ public:
 	void mapSo(unsigned nr51);
 	unsigned getStatus() const;
 
-	std::size_t callbackCycleOffset(unsigned long cycleCounter, bool doubleSpeed);
+	unsigned long callbackCycleOffset(unsigned long cycleCounter, bool doubleSpeed) const;
 	unsigned char pcm12Read(unsigned long cycleCounter, bool doubleSpeed);
 	unsigned char pcm34Read(unsigned long cycleCounter, bool doubleSpeed);
 

--- a/libgambatte/src/sound.h
+++ b/libgambatte/src/sound.h
@@ -30,7 +30,7 @@ namespace gambatte {
 class PSG {
 public:
 	PSG();
-	void init(bool cgb);
+	void init(bool cgb, bool agb);
 	void reset(bool ds);
 	void divReset(bool ds);
 	void setStatePtrs(SaveState &state);

--- a/libgambatte/src/sound/channel1.cpp
+++ b/libgambatte/src/sound/channel1.cpp
@@ -246,6 +246,8 @@ void Channel1::update(uint_least32_t *buf, unsigned long const soBaseVol, unsign
 		}
 	}
 
+	vol_ = dutyUnit_.isHighState(cc) ? envelopeUnit_.getVolume() : 0;
+
 	if (cc >= SoundUnit::counter_max) {
 		dutyUnit_.resetCounters(cc);
 		lengthCounter_.resetCounters(cc);

--- a/libgambatte/src/sound/channel1.cpp
+++ b/libgambatte/src/sound/channel1.cpp
@@ -148,7 +148,8 @@ void Channel1::setNr1(unsigned data, unsigned long cc) {
 }
 
 void Channel1::setNr2(unsigned data, unsigned long cc) {
-	if (envelopeUnit_.nr2Change(data, cc))
+	envelopeUnit_.nr2Change(data, cc, master_);
+	if (!(data & (psg_nr2_initvol | psg_nr2_inc)))
 		disableMaster_();
 	else
 		staticOutputTest_(cc);

--- a/libgambatte/src/sound/channel1.cpp
+++ b/libgambatte/src/sound/channel1.cpp
@@ -123,6 +123,7 @@ Channel1::Channel1()
 , soMask_(0)
 , prevOut_(0)
 , nr4_(0)
+, vol_(0)
 , master_(false)
 {
 	setEvent();
@@ -190,8 +191,9 @@ void Channel1::reset() {
 	setEvent();
 }
 
-void Channel1::init(bool cgb) {
+void Channel1::init(bool cgb, bool agb) {
 	sweepUnit_.init(cgb);
+	envelopeUnit_.init(agb);
 }
 
 void Channel1::saveState(SaveState &state, unsigned long cc) {

--- a/libgambatte/src/sound/channel1.cpp
+++ b/libgambatte/src/sound/channel1.cpp
@@ -148,7 +148,7 @@ void Channel1::setNr1(unsigned data, unsigned long cc) {
 }
 
 void Channel1::setNr2(unsigned data, unsigned long cc) {
-	if (envelopeUnit_.nr2Change(data))
+	if (envelopeUnit_.nr2Change(data, cc))
 		disableMaster_();
 	else
 		staticOutputTest_(cc);

--- a/libgambatte/src/sound/channel1.h
+++ b/libgambatte/src/sound/channel1.h
@@ -45,7 +45,7 @@ public:
 	void update(uint_least32_t *buf, unsigned long soBaseVol, unsigned long cc, unsigned long end);
 	void reset();
 	void resetCc(unsigned long cc, unsigned long ncc) { dutyUnit_.resetCc(cc, ncc); }
-	void init(bool cgb);
+	void init(bool cgb, bool agb);
 	void saveState(SaveState &state, unsigned long cc);
 	void loadState(SaveState const &state);
 	template<bool isReader>void SyncState(NewState *ns);

--- a/libgambatte/src/sound/channel1.h
+++ b/libgambatte/src/sound/channel1.h
@@ -40,6 +40,7 @@ public:
 	void setNr3(unsigned data, unsigned long cc);
 	void setNr4(unsigned data, unsigned long cc, unsigned long ref);
 	void setSo(unsigned long soMask, unsigned long cc);
+	unsigned char getVolume() const { return vol_; }
 	bool isActive() const { return master_; }
 	void update(uint_least32_t *buf, unsigned long soBaseVol, unsigned long cc, unsigned long end);
 	void reset();
@@ -85,6 +86,7 @@ private:
 	unsigned long soMask_;
 	unsigned long prevOut_;
 	unsigned char nr4_;
+	unsigned char vol_;
 	bool master_;
 
 	void setEvent();

--- a/libgambatte/src/sound/channel2.cpp
+++ b/libgambatte/src/sound/channel2.cpp
@@ -140,6 +140,8 @@ void Channel2::update(uint_least32_t *buf, unsigned long const soBaseVol, unsign
 		}
 	}
 
+	vol_ = dutyUnit_.isHighState(cc) ? envelopeUnit_.getVolume() : 0;
+
 	if (cc >= SoundUnit::counter_max) {
 		dutyUnit_.resetCounters(cc);
 		lengthCounter_.resetCounters(cc);

--- a/libgambatte/src/sound/channel2.cpp
+++ b/libgambatte/src/sound/channel2.cpp
@@ -50,7 +50,8 @@ void Channel2::setNr1(unsigned data, unsigned long cc) {
 }
 
 void Channel2::setNr2(unsigned data, unsigned long cc) {
-	if (envelopeUnit_.nr2Change(data, cc))
+	envelopeUnit_.nr2Change(data, cc, master_);
+	if (!(data & (psg_nr2_initvol | psg_nr2_inc)))
 		disableMaster_();
 	else
 		staticOutputTest_(cc);

--- a/libgambatte/src/sound/channel2.cpp
+++ b/libgambatte/src/sound/channel2.cpp
@@ -32,6 +32,7 @@ Channel2::Channel2()
 , soMask_(0)
 , prevOut_(0)
 , nr4_(0)
+, vol_(0)
 , master_(false)
 {
 	setEvent();
@@ -88,6 +89,10 @@ void Channel2::reset() {
 	dutyUnit_.reset();
 	envelopeUnit_.reset();
 	setEvent();
+}
+
+void Channel2::init(bool agb) {
+	envelopeUnit_.init(agb);
 }
 
 void Channel2::saveState(SaveState &state, unsigned long cc) {

--- a/libgambatte/src/sound/channel2.cpp
+++ b/libgambatte/src/sound/channel2.cpp
@@ -50,7 +50,7 @@ void Channel2::setNr1(unsigned data, unsigned long cc) {
 }
 
 void Channel2::setNr2(unsigned data, unsigned long cc) {
-	if (envelopeUnit_.nr2Change(data))
+	if (envelopeUnit_.nr2Change(data, cc))
 		disableMaster_();
 	else
 		staticOutputTest_(cc);

--- a/libgambatte/src/sound/channel2.h
+++ b/libgambatte/src/sound/channel2.h
@@ -43,6 +43,7 @@ public:
 	void update(uint_least32_t *buf, unsigned long soBaseVol, unsigned long cc, unsigned long end);
 	void reset();
 	void resetCc(unsigned long cc, unsigned long ncc) { dutyUnit_.resetCc(cc, ncc); }
+	void init(bool agb);
 	void saveState(SaveState &state, unsigned long cc);
 	void loadState(SaveState const &state);
 	template<bool isReader>void SyncState(NewState *ns);

--- a/libgambatte/src/sound/channel2.h
+++ b/libgambatte/src/sound/channel2.h
@@ -39,6 +39,7 @@ public:
 	void setNr4(unsigned data, unsigned long cc, unsigned long ref);
 	void setSo(unsigned long soMask, unsigned long cc);
 	bool isActive() const { return master_; }
+	unsigned char getVolume() const { return vol_; }
 	void update(uint_least32_t *buf, unsigned long soBaseVol, unsigned long cc, unsigned long end);
 	void reset();
 	void resetCc(unsigned long cc, unsigned long ncc) { dutyUnit_.resetCc(cc, ncc); }
@@ -58,6 +59,7 @@ private:
 	unsigned long soMask_;
 	unsigned long prevOut_;
 	unsigned char nr4_;
+	unsigned char vol_;
 	bool master_;
 
 	void setEvent();

--- a/libgambatte/src/sound/channel3.cpp
+++ b/libgambatte/src/sound/channel3.cpp
@@ -205,6 +205,8 @@ void Channel3::update(uint_least32_t *buf, unsigned long const soBaseVol, unsign
 		updateWaveCounter(cc);
 	}
 
+	vol_ = (wavePos_ % 2 ? sampleBuf_ & 0xF : sampleBuf_ >> 4) >> rshift_;
+
 	if (cc >= SoundUnit::counter_max) {
 		lengthCounter_.resetCounters(cc);
 		lastReadTime_ -= SoundUnit::counter_max;

--- a/libgambatte/src/sound/channel3.cpp
+++ b/libgambatte/src/sound/channel3.cpp
@@ -46,6 +46,7 @@ Channel3::Channel3()
 , wavePos_(0)
 , rshift_(4)
 , sampleBuf_(0)
+, vol_(0)
 , master_(false)
 , cgb_(false)
 {
@@ -153,7 +154,7 @@ void Channel3::update(uint_least32_t *buf, unsigned long const soBaseVol, unsign
 				std::min(lengthCounter_.counter(), end);
 			unsigned long cnt = waveCounter_, prevOut = prevOut_;
 			unsigned long out = master_
-				? ((pos % 2 ? sampleBuf_ & 0xF : sampleBuf_ >> 4) >> rsh) * 2l - 15
+				? waveSample(pos, sampleBuf_, rsh) * 2l - 15
 				: -15;
 			out *= outBase;
 			while (cnt <= nextMajorEvent) {
@@ -164,7 +165,7 @@ void Channel3::update(uint_least32_t *buf, unsigned long const soBaseVol, unsign
 				cnt += period;
 				++pos;
 				unsigned const s = waveRam_[pos / 2 % sizeof waveRam_];
-				out = ((pos % 2 ? s & 0xF : s >> 4) >> rsh) * 2l - 15;
+				out = waveSample(pos, s, rsh) * 2l - 15;
 				out *= outBase;
 			}
 			if (cnt != waveCounter_) {
@@ -185,7 +186,7 @@ void Channel3::update(uint_least32_t *buf, unsigned long const soBaseVol, unsign
 		}
 		if (cc < end) {
 			unsigned long out = master_
-				? ((wavePos_ % 2 ? sampleBuf_ & 0xF : sampleBuf_ >> 4) >> rshift_) * 2l - 15
+				? waveSample(wavePos_, sampleBuf_, rshift_) * 2l - 15
 				: -15;
 			out *= outBase;
 			*buf += out - prevOut_;
@@ -205,7 +206,7 @@ void Channel3::update(uint_least32_t *buf, unsigned long const soBaseVol, unsign
 		updateWaveCounter(cc);
 	}
 
-	vol_ = (wavePos_ % 2 ? sampleBuf_ & 0xF : sampleBuf_ >> 4) >> rshift_;
+	vol_ = waveSample(wavePos_, sampleBuf_, rshift_);
 
 	if (cc >= SoundUnit::counter_max) {
 		lengthCounter_.resetCounters(cc);

--- a/libgambatte/src/sound/channel3.h
+++ b/libgambatte/src/sound/channel3.h
@@ -104,6 +104,10 @@ private:
 	bool cgb_;
 
 	void updateWaveCounter(unsigned long cc);
+
+	inline unsigned char waveSample(unsigned pos, unsigned char s, unsigned char rsh) const {
+		return (pos % 2 ? s & 0xF : s >> 4) >> rsh;
+	}
 };
 
 }

--- a/libgambatte/src/sound/channel3.h
+++ b/libgambatte/src/sound/channel3.h
@@ -31,6 +31,7 @@ struct SaveState;
 class Channel3 {
 public:
 	Channel3();
+	unsigned char getVolume() const { return vol_; }
 	bool isActive() const { return master_; }
 	bool isCgb() const { return cgb_; }
 	void reset();
@@ -98,6 +99,7 @@ private:
 	unsigned char wavePos_;
 	unsigned char rshift_;
 	unsigned char sampleBuf_;
+	unsigned char vol_;
 	bool master_;
 	bool cgb_;
 

--- a/libgambatte/src/sound/channel4.cpp
+++ b/libgambatte/src/sound/channel4.cpp
@@ -95,6 +95,11 @@ inline void Channel4::Lfsr::event() {
 	backupCounter_ = counter_;
 }
 
+bool Channel4::Lfsr::isHighState(unsigned long const cc) {
+	updateBackupCounter(cc);
+	return ~reg_ & 1;
+}
+
 void Channel4::Lfsr::nr3Change(unsigned newNr3, unsigned long cc) {
 	updateBackupCounter(cc);
 	nr3_ = newNr3;
@@ -263,6 +268,8 @@ void Channel4::update(uint_least32_t *buf, unsigned long const soBaseVol, unsign
 			setEvent();
 		}
 	}
+
+	vol_ = lfsr_.isHighState(cc) ? envelopeUnit_.getVolume() : 0;
 
 	if (cc >= SoundUnit::counter_max) {
 		lengthCounter_.resetCounters(cc);

--- a/libgambatte/src/sound/channel4.cpp
+++ b/libgambatte/src/sound/channel4.cpp
@@ -182,7 +182,7 @@ void Channel4::setNr1(unsigned data, unsigned long cc) {
 }
 
 void Channel4::setNr2(unsigned data, unsigned long cc) {
-	if (envelopeUnit_.nr2Change(data))
+	if (envelopeUnit_.nr2Change(data, cc))
 		disableMaster_();
 	else
 		staticOutputTest_(cc);

--- a/libgambatte/src/sound/channel4.cpp
+++ b/libgambatte/src/sound/channel4.cpp
@@ -54,7 +54,7 @@ void Channel4::Lfsr::updateBackupCounter(unsigned long const cc) {
 		unsigned long periods = (cc - backupCounter_) / period + 1;
 		backupCounter_ += periods * period;
 
-		if (master_ && nr3_ < 0xE * (1u * psg_nr43_s & -psg_nr43_s)) {
+		if ((master_ || !cgb_) && nr3_ < 0xE * (1u * psg_nr43_s & -psg_nr43_s)) {
 			if (nr3_ & psg_nr43_7biten) {
 				while (periods > 6) {
 					unsigned const xored = (reg_ << 1 ^ reg_) & 0x7E;
@@ -154,6 +154,7 @@ void Channel4::Lfsr::SyncState(NewState *ns) {
 	NSS(reg_);
 	NSS(nr3_);
 	NSS(master_);
+	NSS(cgb_);
 }
 
 Channel4::Channel4()
@@ -165,6 +166,7 @@ Channel4::Channel4()
 , soMask_(0)
 , prevOut_(0)
 , nr4_(0)
+, vol_(0)
 , master_(false)
 {
 	setEvent();
@@ -217,6 +219,11 @@ void Channel4::reset(unsigned long cc) {
 	lfsr_.reset(cc);
 	envelopeUnit_.reset();
 	setEvent();
+}
+
+void Channel4::init(bool cgb, bool agb) {
+	lfsr_.init(cgb);
+	envelopeUnit_.init(agb);
 }
 
 void Channel4::saveState(SaveState &state, unsigned long cc) {

--- a/libgambatte/src/sound/channel4.cpp
+++ b/libgambatte/src/sound/channel4.cpp
@@ -182,7 +182,8 @@ void Channel4::setNr1(unsigned data, unsigned long cc) {
 }
 
 void Channel4::setNr2(unsigned data, unsigned long cc) {
-	if (envelopeUnit_.nr2Change(data, cc))
+	envelopeUnit_.nr2Change(data, cc, master_);
+	if (!(data & (psg_nr2_initvol | psg_nr2_inc)))
 		disableMaster_();
 	else
 		staticOutputTest_(cc);

--- a/libgambatte/src/sound/channel4.h
+++ b/libgambatte/src/sound/channel4.h
@@ -43,6 +43,7 @@ public:
 	void update(uint_least32_t *buf, unsigned long soBaseVol, unsigned long cc, unsigned long end);
 	void reset(unsigned long cc);
 	void resetCc(unsigned long cc, unsigned long newCc) { lfsr_.resetCc(cc, newCc); }
+	void init(bool cgb, bool agb);
 	void saveState(SaveState &state, unsigned long cc);
 	void loadState(SaveState const &state);
 	template<bool isReader>void SyncState(NewState *ns);
@@ -59,6 +60,7 @@ private:
 		void nr4Init(unsigned long cc);
 		void reset(unsigned long cc);
 		void resetCc(unsigned long cc, unsigned long newCc);
+		void init(bool cgb) { cgb_ = cgb; }
 		void saveState(SaveState &state, unsigned long cc);
 		void loadState(SaveState const &state);
 		void disableMaster() { killCounter(); master_ = false; reg_ = 0x7FFF; }
@@ -71,6 +73,7 @@ private:
 		unsigned short reg_;
 		unsigned char nr3_;
 		bool master_;
+		bool cgb_;
 
 		void updateBackupCounter(unsigned long cc);
 	};

--- a/libgambatte/src/sound/channel4.h
+++ b/libgambatte/src/sound/channel4.h
@@ -38,6 +38,7 @@ public:
 	void setNr3(unsigned data, unsigned long cc) { lfsr_.nr3Change(data, cc); }
 	void setNr4(unsigned data, unsigned long cc);
 	void setSo(unsigned long soMask, unsigned long cc);
+	unsigned char getVolume() const { return vol_; }
 	bool isActive() const { return master_; }
 	void update(uint_least32_t *buf, unsigned long soBaseVol, unsigned long cc, unsigned long end);
 	void reset(unsigned long cc);
@@ -53,6 +54,7 @@ private:
 		virtual void event();
 		virtual void resetCounters(unsigned long oldCc);
 		bool isHighState() const { return ~reg_ & 1; }
+		bool isHighState(unsigned long cc);
 		void nr3Change(unsigned newNr3, unsigned long cc);
 		void nr4Init(unsigned long cc);
 		void reset(unsigned long cc);
@@ -93,6 +95,7 @@ private:
 	unsigned long soMask_;
 	unsigned long prevOut_;
 	unsigned char nr4_;
+	unsigned char vol_;
 	bool master_;
 
 	void setEvent();

--- a/libgambatte/src/sound/duty_unit.cpp
+++ b/libgambatte/src/sound/duty_unit.cpp
@@ -96,6 +96,15 @@ void DutyUnit::event() {
 	inc_ = inc[duty_][high_];
 }
 
+bool DutyUnit::isHighState(unsigned long const cc) const {
+	if (nextPosUpdate_ == counter_disabled)
+		return false;
+
+	unsigned long const inc = (cc - nextPosUpdate_) / period_ + 1;
+	unsigned char const pos = (pos_ + inc) % duty_pattern_len;
+	return toOutState(duty_, pos);
+}
+
 void DutyUnit::nr1Change(unsigned newNr1, unsigned long cc) {
 	updatePos(cc);
 	duty_ = newNr1 >> 6;

--- a/libgambatte/src/sound/duty_unit.cpp
+++ b/libgambatte/src/sound/duty_unit.cpp
@@ -100,9 +100,13 @@ bool DutyUnit::isHighState(unsigned long const cc) const {
 	if (nextPosUpdate_ == counter_disabled)
 		return false;
 
-	unsigned long const inc = (cc - nextPosUpdate_) / period_ + 1;
-	unsigned char const pos = (pos_ + inc) % duty_pattern_len;
-	return toOutState(duty_, pos);
+	bool high = high_;
+	if (cc >= nextPosUpdate_) {
+		unsigned long const inc = (cc - nextPosUpdate_) / period_ + 1;
+		unsigned char const pos = (pos_ + inc) % duty_pattern_len;
+		high = toOutState(duty_, pos);
+	}
+	return high;
 }
 
 void DutyUnit::nr1Change(unsigned newNr1, unsigned long cc) {

--- a/libgambatte/src/sound/duty_unit.cpp
+++ b/libgambatte/src/sound/duty_unit.cpp
@@ -97,9 +97,6 @@ void DutyUnit::event() {
 }
 
 bool DutyUnit::isHighState(unsigned long const cc) const {
-	if (nextPosUpdate_ == counter_disabled)
-		return false;
-
 	bool high = high_;
 	if (cc >= nextPosUpdate_) {
 		unsigned long const inc = (cc - nextPosUpdate_) / period_ + 1;

--- a/libgambatte/src/sound/duty_unit.h
+++ b/libgambatte/src/sound/duty_unit.h
@@ -32,6 +32,7 @@ public:
 	virtual void event();
 	virtual void resetCounters(unsigned long oldCc);
 	bool isHighState() const { return high_; }
+	bool isHighState(unsigned long cc) const;
 	void nr1Change(unsigned newNr1, unsigned long cc);
 	void nr3Change(unsigned newNr3, unsigned long cc);
 	void nr4Change(unsigned newNr4, unsigned long cc, unsigned long ref, bool master);

--- a/libgambatte/src/sound/envelope_unit.cpp
+++ b/libgambatte/src/sound/envelope_unit.cpp
@@ -29,7 +29,17 @@ EnvelopeUnit::EnvelopeUnit(VolOnOffEvent &volOnOffEvent)
 : volOnOffEvent_(volOnOffEvent)
 , nr2_(0)
 , volume_(0)
+, clock_(false)
 {
+}
+
+bool EnvelopeUnit::clock(unsigned long const cc) {
+	if (counter_ == counter_disabled)
+		return false;
+
+	bool clock = (cc & 0x7800) == 0x1800 && clock_;
+	clock_ = cc & -0x7FFF;
+	return clock;
 }
 
 void EnvelopeUnit::reset() {
@@ -69,8 +79,17 @@ void EnvelopeUnit::event() {
 		counter_ += 8ul << 15;
 }
 
-bool EnvelopeUnit::nr2Change(unsigned const newNr2, unsigned long const cc) {
-	counter_ = cc + ((newNr2 & psg_nr2_step) << 15);
+void EnvelopeUnit::nr2Change(unsigned const newNr2, unsigned long const cc, bool const master) {
+	if (!master) {
+		nr2_ = newNr2;
+		return;
+	}
+
+	bool willClock = clock(cc);
+	if (willClock) {
+		unsigned long const period = nr2_ & psg_nr2_step;
+		counter_ = cc - ((cc - 0x1000) & 0x7FFF) + period * 0x8000;
+	}
 
 	bool tick = (newNr2 & psg_nr2_step) && !(nr2_ & psg_nr2_step) && counter_ != counter_disabled;
 	bool invert = (newNr2 & psg_nr2_inc) ^ (nr2_ & psg_nr2_inc);
@@ -101,16 +120,17 @@ bool EnvelopeUnit::nr2Change(unsigned const newNr2, unsigned long const cc) {
 			--volume_;
 
 		volume_ &= 0xF;
-	} else if (!(newNr2 & psg_nr2_step)) {
+	} else if (!(newNr2 & psg_nr2_step) && willClock) {
 		if (invert) {
 			if (volume_ == ((newNr2 & psg_nr2_inc) ? 0xE : 0x1))
 				counter_ = counter_disabled;
 		} else if (volume_ == ((newNr2 & psg_nr2_inc) ? 0xF : 0x0))
 			counter_ = counter_disabled;
+
+		clock_ = false;
 	}
 
 	nr2_ = newNr2;
-	return !(newNr2 & (psg_nr2_initvol | psg_nr2_inc));
 }
 
 bool EnvelopeUnit::nr4Init(unsigned long const cc) {

--- a/libgambatte/src/sound/envelope_unit.cpp
+++ b/libgambatte/src/sound/envelope_unit.cpp
@@ -30,16 +30,8 @@ EnvelopeUnit::EnvelopeUnit(VolOnOffEvent &volOnOffEvent)
 , nr2_(0)
 , volume_(0)
 , clock_(false)
+, agb_(false)
 {
-}
-
-bool EnvelopeUnit::clock(unsigned long const cc) {
-	if (counter_ == counter_disabled)
-		return false;
-
-	bool clock = (cc & 0x7800) == 0x1800 && clock_;
-	clock_ = cc & -0x7FFF;
-	return clock;
 }
 
 void EnvelopeUnit::reset() {
@@ -49,12 +41,14 @@ void EnvelopeUnit::reset() {
 void EnvelopeUnit::saveState(SaveState::SPU::Env &estate) const {
 	estate.counter = counter_;
 	estate.volume = volume_;
+	estate.clock = clock_;
 }
 
 void EnvelopeUnit::loadState(SaveState::SPU::Env const &estate, unsigned nr2, unsigned long cc) {
 	counter_ = std::max(estate.counter, cc);
 	volume_ = estate.volume;
 	nr2_ = nr2;
+	clock_ = estate.clock;
 }
 
 void EnvelopeUnit::event() {
@@ -149,4 +143,6 @@ SYNCFUNC(EnvelopeUnit) {
 	NSS(counter_);
 	NSS(nr2_);
 	NSS(volume_);
+	NSS(clock_);
+	NSS(agb_);
 }

--- a/libgambatte/src/sound/envelope_unit.h
+++ b/libgambatte/src/sound/envelope_unit.h
@@ -34,11 +34,12 @@ public:
 
 	explicit EnvelopeUnit(VolOnOffEvent &volOnOffEvent = nullEvent_);
 	void event();
-	bool dacIsOn() const { return nr2_ & 0xF8; }
+	bool dacIsOn() const { return agb_ || (nr2_ & 0xF8); }
 	unsigned getVolume() const { return volume_; }
 	void nr2Change(unsigned newNr2, unsigned long cc, bool master);
 	bool nr4Init(unsigned long cycleCounter);
 	void reset();
+	void init(bool agb) { agb_ = agb; }
 	void saveState(SaveState::SPU::Env &estate) const;
 	void loadState(SaveState::SPU::Env const &estate, unsigned nr2, unsigned long cc);
 	template<bool isReader>void SyncState(NewState *ns);
@@ -49,8 +50,16 @@ private:
 	unsigned char nr2_;
 	unsigned char volume_;
 	bool clock_;
+	bool agb_;
 
-	bool clock(unsigned long cc);
+	bool clock(unsigned long cc) {
+		if (counter_ == counter_disabled)
+			return false;
+
+		bool clock = (cc & 0x7800) == 0x1800 && clock_;
+		clock_ = (cc % counter_) & ~0x7FFF;
+		return clock;
+	}
 };
 
 }

--- a/libgambatte/src/sound/envelope_unit.h
+++ b/libgambatte/src/sound/envelope_unit.h
@@ -36,7 +36,7 @@ public:
 	void event();
 	bool dacIsOn() const { return nr2_ & 0xF8; }
 	unsigned getVolume() const { return volume_; }
-	bool nr2Change(unsigned newNr2, unsigned long cc);
+	void nr2Change(unsigned newNr2, unsigned long cc, bool master);
 	bool nr4Init(unsigned long cycleCounter);
 	void reset();
 	void saveState(SaveState::SPU::Env &estate) const;
@@ -48,6 +48,9 @@ private:
 	VolOnOffEvent &volOnOffEvent_;
 	unsigned char nr2_;
 	unsigned char volume_;
+	bool clock_;
+
+	bool clock(unsigned long cc);
 };
 
 }

--- a/libgambatte/src/sound/envelope_unit.h
+++ b/libgambatte/src/sound/envelope_unit.h
@@ -36,7 +36,7 @@ public:
 	void event();
 	bool dacIsOn() const { return nr2_ & 0xF8; }
 	unsigned getVolume() const { return volume_; }
-	bool nr2Change(unsigned newNr2);
+	bool nr2Change(unsigned newNr2, unsigned long cc);
 	bool nr4Init(unsigned long cycleCounter);
 	void reset();
 	void saveState(SaveState::SPU::Env &estate) const;

--- a/libgambatte/src/sound/envelope_unit.h
+++ b/libgambatte/src/sound/envelope_unit.h
@@ -57,7 +57,7 @@ private:
 			return false;
 
 		bool clock = (cc & 0x7800) == 0x1800 && clock_;
-		clock_ = (cc % counter_) & ~0x7FFF;
+		clock_ = (counter_ % cc) & ~0x7FFF;
 		return clock;
 	}
 };

--- a/libgambatte/src/statesaver.cpp
+++ b/libgambatte/src/statesaver.cpp
@@ -319,6 +319,7 @@ SaverList::SaverList()
 	{ static char const label[] = { d,u,t,NO1,h,i,   NUL }; ADD(spu.ch1.duty.high); }
 	{ static char const label[] = { e,n,v,NO1,c,t,r, NUL }; ADD(spu.ch1.env.counter); }
 	{ static char const label[] = { e,n,v,NO1,v,o,l, NUL }; ADD(spu.ch1.env.volume); }
+	{ static char const label[] = { e,n,v,NO1,c,l,k, NUL }; ADD(spu.ch1.env.clock); }
 	{ static char const label[] = { l,e,n,NO1,c,t,r, NUL }; ADD(spu.ch1.lcounter.counter); }
 	{ static char const label[] = { l,e,n,NO1,v,a,l, NUL }; ADD(spu.ch1.lcounter.lengthCounter); }
 	{ static char const label[] = { n,r,NO1,NO0,       NUL }; ADD(spu.ch1.sweep.nr0); }
@@ -330,6 +331,7 @@ SaverList::SaverList()
 	{ static char const label[] = { d,u,t,NO2,h,i,   NUL }; ADD(spu.ch2.duty.high); }
 	{ static char const label[] = { e,n,v,NO2,c,t,r, NUL }; ADD(spu.ch2.env.counter); }
 	{ static char const label[] = { e,n,v,NO2,v,o,l, NUL }; ADD(spu.ch2.env.volume); }
+	{ static char const label[] = { e,n,v,NO2,c,l,k, NUL }; ADD(spu.ch2.env.clock); }
 	{ static char const label[] = { l,e,n,NO2,c,t,r, NUL }; ADD(spu.ch2.lcounter.counter); }
 	{ static char const label[] = { l,e,n,NO2,v,a,l, NUL }; ADD(spu.ch2.lcounter.lengthCounter); }
 	{ static char const label[] = { n,r,NO2,NO3,       NUL }; ADD(spu.ch2.duty.nr3); }
@@ -349,6 +351,7 @@ SaverList::SaverList()
 	{ static char const label[] = { l,f,s,r,r,e,g, NUL }; ADD(spu.ch4.lfsr.reg); }
 	{ static char const label[] = { e,n,v,NO4,c,t,r, NUL }; ADD(spu.ch4.env.counter); }
 	{ static char const label[] = { e,n,v,NO4,v,o,l, NUL }; ADD(spu.ch4.env.volume); }
+	{ static char const label[] = { e,n,v,NO4,c,l,k, NUL }; ADD(spu.ch4.env.clock); }
 	{ static char const label[] = { l,e,n,NO4,c,t,r, NUL }; ADD(spu.ch4.lcounter.counter); }
 	{ static char const label[] = { l,e,n,NO4,v,a,l, NUL }; ADD(spu.ch4.lcounter.lengthCounter); }
 	{ static char const label[] = { n,r,NO4,NO4,       NUL }; ADD(spu.ch4.nr4); }


### PR DESCRIPTION
Adds support for the PCM registers ($FF76/$FF77). Includes improvements in APU code (taken from SameBoy), including better emulation of NRx2 writes ("Zombie Mode"), always treating the DAC as always on in AGB mode, and advancing the noise channel LFSR regardless of enabled status on the DMG. Also included is masking of extra OAM as a CGB-C does. Technically we want to emulate a CGB-E in the future, but for now CGB-C code for extra OAM should be used until we have all the other CGB-C code taken out with proper E tests to replace them (mostly rather not have testroms identify us as not a D and just as a C until we are a true E, so to speak).

Also changed callbackCycleOffset to not force update all the channels and just calc the bufferPos offset and use that. Should be far more performative when callbacks are active.