### PR TITLE
SGB Qt + Misc Fixes

### DIFF
--- a/common/videolink/vfilterinfo.cpp
+++ b/common/videolink/vfilterinfo.cpp
@@ -33,7 +33,9 @@ static VideoLink * createT() { return new T; }
 
 static VfilterInfo const vfinfos[] = {
 	{ "None", VfilterInfo::in_width, VfilterInfo::in_height, createNone },
+#ifdef SHOW_PLATFORM_SGB
 	VFINFO("SGB Border", SgbBorder),
+#endif
 	VFINFO("Bicubic Catmull-Rom spline 2x", Catrom2x),
 	VFINFO("Bicubic Catmull-Rom spline 3x", Catrom3x),
 	VFINFO("Kreed's 2xSaI", Kreed2xSaI),

--- a/common/videolink/vfilterinfo.cpp
+++ b/common/videolink/vfilterinfo.cpp
@@ -32,6 +32,7 @@ static VideoLink * createT() { return new T; }
 
 static VfilterInfo const vfinfos[] = {
 	{ "None", VfilterInfo::in_width, VfilterInfo::in_height, createNone },
+	{ "SGB Border", 256, 224, createNone },
 	VFINFO("Bicubic Catmull-Rom spline 2x", Catrom2x),
 	VFINFO("Bicubic Catmull-Rom spline 3x", Catrom3x),
 	VFINFO("Kreed's 2xSaI", Kreed2xSaI),

--- a/common/videolink/vfilters/sgbborder.cpp
+++ b/common/videolink/vfilters/sgbborder.cpp
@@ -27,11 +27,11 @@ enum { in_height = SgbBorder::out_height };
 enum { in_pitch  = in_width + 3 };
 
 static void blit(gambatte::uint_least32_t *d,
-                std::ptrdiff_t const dstPitch,
-                gambatte::uint_least32_t const *s,
-                std::ptrdiff_t const srcPitch,
-                unsigned const w,
-                unsigned h)
+                 std::ptrdiff_t const dstPitch,
+                 gambatte::uint_least32_t const *s,
+                 std::ptrdiff_t const srcPitch,
+                 unsigned const w,
+                 unsigned h)
 {
 	do {
 		std::ptrdiff_t i = -static_cast<std::ptrdiff_t>(w);

--- a/common/videolink/vfilters/sgbborder.cpp
+++ b/common/videolink/vfilters/sgbborder.cpp
@@ -17,7 +17,6 @@
  *   51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.             *
  ***************************************************************************/
 #include "sgbborder.h"
-
 #include <algorithm>
 
 namespace {

--- a/common/videolink/vfilters/sgbborder.cpp
+++ b/common/videolink/vfilters/sgbborder.cpp
@@ -19,13 +19,33 @@
 #include "sgbborder.h"
 
 #include <algorithm>
-#include <cstring>
 
 namespace {
 
 enum { in_width  = SgbBorder::out_width };
 enum { in_height = SgbBorder::out_height };
 enum { in_pitch  = in_width + 3 };
+
+static void blit(gambatte::uint_least32_t *d,
+                std::ptrdiff_t const dstPitch,
+                gambatte::uint_least32_t const *s,
+                std::ptrdiff_t const srcPitch,
+                unsigned const w,
+                unsigned h)
+{
+	do {
+		std::ptrdiff_t i = -static_cast<std::ptrdiff_t>(w);
+		s += w;
+		d += w;
+
+		do {
+			d[i] = s[i];
+		} while (++i);
+
+		s += srcPitch - static_cast<std::ptrdiff_t>(w);
+		d += dstPitch - static_cast<std::ptrdiff_t>(w);
+	} while (--h);
+}
 
 } // anon namespace
 
@@ -44,10 +64,6 @@ std::ptrdiff_t SgbBorder::inPitch() const {
 }
 
 void SgbBorder::draw(void *dbuffer, std::ptrdiff_t pitch) {
-	gambatte::uint_least32_t *outBuf_ = (gambatte::uint_least32_t *)dbuffer;
-	gambatte::uint_least32_t *inBuf_ = (gambatte::uint_least32_t *)inBuf();
-	for (unsigned j = 0; j < in_width; j++) {
-		for (unsigned i = 0; i < in_height; i++)
-			outBuf_[j * pitch + i] = inBuf_[j * in_pitch + i];
-	}
+	::blit(static_cast<gambatte::uint_least32_t *>(dbuffer), pitch,
+	       static_cast<gambatte::uint_least32_t *>(inBuf()), in_pitch, in_width, in_height);
 }

--- a/common/videolink/vfilters/sgbborder.cpp
+++ b/common/videolink/vfilters/sgbborder.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2009 by Sindre Aamås                                    *
+ *   Copyright (C) 2007 by Sindre Aamås                                    *
  *   sinamas@users.sourceforge.net                                         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -16,35 +16,38 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.             *
  ***************************************************************************/
-#include "vfilterinfo.h"
-#include "vfilters/sgbborder.h"
-#include "vfilters/catrom2x.h"
-#include "vfilters/catrom3x.h"
-#include "vfilters/kreed2xsai.h"
-#include "vfilters/maxsthq2x.h"
-#include "vfilters/maxsthq3x.h"
+#include "sgbborder.h"
 
-static VideoLink * createNone() { return 0; }
+#include <algorithm>
+#include <cstring>
 
-template<class T>
-static VideoLink * createT() { return new T; }
+namespace {
 
-#define VFINFO(handle, Type) { handle, Type::out_width, Type::out_height, createT<Type> }
+enum { in_width  = SgbBorder::out_width };
+enum { in_height = SgbBorder::out_height };
+enum { in_pitch  = in_width + 3 };
 
-static VfilterInfo const vfinfos[] = {
-	{ "None", VfilterInfo::in_width, VfilterInfo::in_height, createNone },
-	VFINFO("SGB Border", SgbBorder),
-	VFINFO("Bicubic Catmull-Rom spline 2x", Catrom2x),
-	VFINFO("Bicubic Catmull-Rom spline 3x", Catrom3x),
-	VFINFO("Kreed's 2xSaI", Kreed2xSaI),
-	VFINFO("MaxSt's hq2x", MaxStHq2x),
-	VFINFO("MaxSt's hq3x", MaxStHq3x),
-};
+} // anon namespace
 
-std::size_t VfilterInfo::numVfilters() {
-	return sizeof vfinfos / sizeof vfinfos[0];
+SgbBorder::SgbBorder()
+: buffer_((in_height + 3UL) * in_pitch)
+{
+	std::fill_n(buffer_.get(), buffer_.size(), 0);
 }
 
-VfilterInfo const & VfilterInfo::get(std::size_t n) {
-	return vfinfos[n];
+void * SgbBorder::inBuf() const {
+	return buffer_ + in_pitch + 1;
+}
+
+std::ptrdiff_t SgbBorder::inPitch() const {
+	return in_pitch;
+}
+
+void SgbBorder::draw(void *dbuffer, std::ptrdiff_t pitch) {
+	gambatte::uint_least32_t *outBuf_ = (gambatte::uint_least32_t *)dbuffer;
+	gambatte::uint_least32_t *inBuf_ = (gambatte::uint_least32_t *)inBuf();
+	for (unsigned j = 0; j < in_width; j++) {
+		for (unsigned i = 0; i < in_height; i++)
+			outBuf_[j * pitch + i] = inBuf_[j * in_pitch + i];
+	}
 }

--- a/common/videolink/vfilters/sgbborder.h
+++ b/common/videolink/vfilters/sgbborder.h
@@ -16,35 +16,26 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.             *
  ***************************************************************************/
-#include "vfilterinfo.h"
-#include "vfilters/sgbborder.h"
-#include "vfilters/catrom2x.h"
-#include "vfilters/catrom3x.h"
-#include "vfilters/kreed2xsai.h"
-#include "vfilters/maxsthq2x.h"
-#include "vfilters/maxsthq3x.h"
+#ifndef SGBBORDER_H
+#define SGBBORDER_H
 
-static VideoLink * createNone() { return 0; }
+#include "../videolink.h"
+#include "../vfilterinfo.h"
+#include "array.h"
+#include "gbint.h"
 
-template<class T>
-static VideoLink * createT() { return new T; }
+class SgbBorder : public VideoLink {
+public:
+	enum { out_width  = VfilterInfo::in_width  + 96 };
+	enum { out_height = VfilterInfo::in_height + 80 };
 
-#define VFINFO(handle, Type) { handle, Type::out_width, Type::out_height, createT<Type> }
+	SgbBorder();
+	virtual void * inBuf() const;
+	virtual std::ptrdiff_t inPitch() const;
+	virtual void draw(void *dst, std::ptrdiff_t dstpitch);
 
-static VfilterInfo const vfinfos[] = {
-	{ "None", VfilterInfo::in_width, VfilterInfo::in_height, createNone },
-	VFINFO("SGB Border", SgbBorder),
-	VFINFO("Bicubic Catmull-Rom spline 2x", Catrom2x),
-	VFINFO("Bicubic Catmull-Rom spline 3x", Catrom3x),
-	VFINFO("Kreed's 2xSaI", Kreed2xSaI),
-	VFINFO("MaxSt's hq2x", MaxStHq2x),
-	VFINFO("MaxSt's hq3x", MaxStHq3x),
+private:
+	Array<gambatte::uint_least32_t> const buffer_;
 };
 
-std::size_t VfilterInfo::numVfilters() {
-	return sizeof vfinfos / sizeof vfinfos[0];
-}
-
-VfilterInfo const & VfilterInfo::get(std::size_t n) {
-	return vfinfos[n];
-}
+#endif

--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -240,6 +240,9 @@ public:
 	/** Returns true if the currently loaded ROM image is treated as having CGB-DMG support. */
 	bool isCgbDmg() const;
 
+	/** Returns true if the currently loaded ROM image is treated as having SGB support. */
+	bool isSgb() const;
+
 	/** Returns true if a ROM image is loaded. */
 	bool isLoaded() const;
 

--- a/libgambatte/src/cpu.h
+++ b/libgambatte/src/cpu.h
@@ -120,6 +120,7 @@ public:
 	void stall(unsigned long cycles) { mem_.stall(cycleCounter_, cycles); }
 	bool isCgb() const { return mem_.isCgb(); }
 	bool isCgbDmg() const { return mem_.isCgbDmg(); }
+	bool isSgb() const { return mem_.isSgb(); }
 
 	void setDmgPaletteColor(int palNum, int colorNum, unsigned long rgb32) {
 		mem_.setDmgPaletteColor(palNum, colorNum, rgb32);

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -274,6 +274,10 @@ bool GB::isCgbDmg() const {
 	return p_->cpu.isCgbDmg();
 }
 
+bool GB::isSgb() const {
+	return p_->cpu.isSgb();
+}
+
 bool GB::isLoaded() const {
 	return p_->cpu.loaded();
 }

--- a/libgambatte/src/initstate.cpp
+++ b/libgambatte/src/initstate.cpp
@@ -261,6 +261,7 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const sgb, bo
 	state.mem.sgb.pending = 0xFF;
 	state.mem.sgb.pendingCount = 0;
 	state.mem.sgb.mask = 0;
+	state.mem.sgb.samplesAccumulated = 0;
 
 	for (int i = 0x00; i < 0x40; i += 0x02) {
 		state.ppu.bgpData.ptr[i    ] = 0xFF;

--- a/libgambatte/src/mem/sgb.cpp
+++ b/libgambatte/src/mem/sgb.cpp
@@ -47,6 +47,7 @@ Sgb::Sgb()
 			for (unsigned r = 0; r < 32; r++)
 				cgbColorsRgb32_[i++] = ((b * 255 + 15) / 31) | (((g * 255 + 15) / 31) << 8) | (((r * 255 + 15) / 31) << 16) | 255 << 24;
 
+	refreshPalettes();
 	spc->init();
 }
 

--- a/libgambatte/src/mem/sgb.cpp
+++ b/libgambatte/src/mem/sgb.cpp
@@ -694,12 +694,10 @@ void Sgb::cmdSound() {
 }
 
 unsigned Sgb::generateSamples(short *soundBuf, std::size_t &samples) {
-	if (!soundBuf)
-		return -1;
-
 	samples = samplesAccumulated_ / 65;
 	samplesAccumulated_ -= samples * 65;
-	spc_set_output(spc, soundBuf, 2048);
+	short buf[2048 * 2];
+	spc_set_output(spc, buf, 2048);
 	bool matched = true;
 	for (unsigned p = 0; p < 4; p++) {
 		if (spc_read_port(spc, 0, p) != soundControl[p])
@@ -714,6 +712,9 @@ unsigned Sgb::generateSamples(short *soundBuf, std::size_t &samples) {
 		spc_write_port(spc, 0, p, soundControl[p]);
 
 	spc_end_frame(spc, samples * 32);
+	if (soundBuf)
+		std::memcpy(soundBuf, buf, sizeof buf);
+
 	return samplesAccumulated_;
 }
 

--- a/libgambatte/src/mem/sgb.cpp
+++ b/libgambatte/src/mem/sgb.cpp
@@ -417,7 +417,7 @@ void Sgb::onTransfer(unsigned char *frame) {
 	switch (pending) {
 	case SOU_TRN:
 	{
-		unsigned char *end = &vram[sizeof vram];
+		unsigned char *end = &vram[(sizeof vram) - 1];
 		unsigned char *src = vram;
 		unsigned char *dst = spc->get_ram();
 		

--- a/libgambatte/src/mem/sgb.cpp
+++ b/libgambatte/src/mem/sgb.cpp
@@ -417,21 +417,21 @@ void Sgb::onTransfer(unsigned char *frame) {
 	switch (pending) {
 	case SOU_TRN:
 	{
-		/*unsigned char *end = vram + 0x10000;*/
+		unsigned char *end = &vram[sizeof vram];
 		unsigned char *src = vram;
 		unsigned char *dst = spc->get_ram();
 		
 		while (true) {
-			/*if (src + 4 > end)
-				break;*/
-			
+			if (src + 4 > end)
+				break;
+
 			unsigned len = src[0] | src[1] << 8;
 			unsigned addr = src[2] | src[3] << 8;
 			if (!len)
 				break;
 
 			src += 4;
-			if (/*(src + len) > end || */(addr + len) >= 0x10000)
+			if ((src + len) > end || (addr + len) >= 0x10000)
 				break;
 
 			std::memcpy(dst + addr, src, len);

--- a/libgambatte/src/mem/sgb.cpp
+++ b/libgambatte/src/mem/sgb.cpp
@@ -417,12 +417,12 @@ void Sgb::onTransfer(unsigned char *frame) {
 	switch (pending) {
 	case SOU_TRN:
 	{
-		unsigned char *end = &vram[(sizeof vram) - 1];
+		unsigned char *end = &vram[sizeof vram];
 		unsigned char *src = vram;
 		unsigned char *dst = spc->get_ram();
 		
 		while (true) {
-			if (src + 4 > end)
+			if (src + 4 >= end)
 				break;
 
 			unsigned len = src[0] | src[1] << 8;
@@ -431,7 +431,7 @@ void Sgb::onTransfer(unsigned char *frame) {
 				break;
 
 			src += 4;
-			if ((src + len) > end || (addr + len) >= 0x10000)
+			if ((src + len) >= end || (addr + len) >= 0x10000)
 				break;
 
 			std::memcpy(dst + addr, src, len);
@@ -721,8 +721,6 @@ unsigned Sgb::generateSamples(short *soundBuf, std::size_t &samples) {
 }
 
 SYNCFUNC(Sgb) {
-	NSS(cgbColorsRgb32_);
-
 	NSS(transfer);
 	NSS(packet);
 	NSS(command);

--- a/libgambatte/src/mem/sgb.cpp
+++ b/libgambatte/src/mem/sgb.cpp
@@ -734,7 +734,6 @@ SYNCFUNC(Sgb) {
 
 	NSS(systemColors);
 	NSS(colors);
-	NSS(palette);
 	NSS(systemAttributes);
 	NSS(attributes);
 

--- a/libgambatte/src/mem/sgb.h
+++ b/libgambatte/src/mem/sgb.h
@@ -21,7 +21,7 @@
 
 #include "gbint.h"
 #include "newstate.h"
-#include "snes_spc/spc.h"
+#include "snes_spc/SNES_SPC.h"
 
 #include <cstddef>
 
@@ -93,7 +93,7 @@ private:
 	unsigned char mask;
 
 	SNES_SPC *spc;
-	unsigned char spcState[spc_state_size];
+	unsigned char spcState[SNES_SPC::state_size];
 	unsigned char soundControl[4];
 	unsigned long samplesAccumulated_;
 

--- a/libgambatte/src/mem/sgb.h
+++ b/libgambatte/src/mem/sgb.h
@@ -43,7 +43,7 @@ public:
 		pitch_ = pitch;
 	}
 
-	void accumulateSamples(unsigned long samples) { samplesAccumulated_ += samples; }
+	void accumulateSamples(std::size_t samples) { samplesAccumulated_ += samples; }
 	unsigned generateSamples(short *soundBuf, std::size_t &samples);
 
 	void setCgbPalette(unsigned *lut) {

--- a/libgambatte/src/mem/snes_spc/SNES_SPC.h
+++ b/libgambatte/src/mem/snes_spc/SNES_SPC.h
@@ -6,7 +6,6 @@
 
 #include "SPC_DSP.h"
 #include "blargg_endian.h"
-#include <stdint.h>
 
 struct SNES_SPC {
 public:

--- a/libgambatte/src/mem/snes_spc/spc.cpp
+++ b/libgambatte/src/mem/snes_spc/spc.cpp
@@ -54,7 +54,6 @@ void spc_end_frame       ( SNES_SPC* s, spc_time_t t )                  { s->end
 void spc_mute_voices     ( SNES_SPC* s, int mask )                      { s->mute_voices( mask ); }
 void spc_disable_surround( SNES_SPC* s, int disable )                   { s->disable_surround( disable ); }
 void spc_set_tempo       ( SNES_SPC* s, int tempo )                     { s->set_tempo( tempo ); }
-uint8_t* spc_get_ram(SNES_SPC* s) { return s->get_ram(); }
 spc_err_t spc_load_spc   ( SNES_SPC* s, void const* p, long n )         { return s->load_spc( p, n ); }
 void spc_clear_echo      ( SNES_SPC* s )                                { s->clear_echo(); }
 spc_err_t spc_play       ( SNES_SPC* s, int count, short* out )         { return s->play( count, out ); }

--- a/libgambatte/src/mem/snes_spc/spc.h
+++ b/libgambatte/src/mem/snes_spc/spc.h
@@ -5,7 +5,6 @@
 #define SPC_H
 
 #include <stddef.h>
-#include <stdint.h>
 
 #ifdef __cplusplus
 	extern "C" {
@@ -60,8 +59,6 @@ void spc_write_port( SNES_SPC*, spc_time_t, int port, int data );
 
 /* Runs SPC to end_time and starts a new time frame at 0 */
 void spc_end_frame( SNES_SPC*, spc_time_t end_time );
-
-uint8_t* spc_get_ram(SNES_SPC*);
 
 /**** Sound control ****/
 

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -351,8 +351,10 @@ public:
 	}
 
 	void setCgbPalette(unsigned *lut) {
-		lcd_.setCgbPalette(lut);
-		sgb_.setCgbPalette(lut);
+		if (isSgb())
+			sgb_.setCgbPalette(lut);
+		else
+			lcd_.setCgbPalette(lut);
 	}
 
 	void setTimeMode(bool useCycles, unsigned long const cc) {

--- a/libgambatte/src/sound.cpp
+++ b/libgambatte/src/sound.cpp
@@ -63,7 +63,7 @@ void PSG::init(bool cgb, bool agb) {
 	ch1_.init(cgb, agb);
 	ch2_.init(agb);
 	ch3_.init(cgb);
-	ch4_.init(cgb, agb);
+	ch4_.init(agb);
 }
 
 void PSG::reset(bool ds) {

--- a/libgambatte/src/sound/channel4.cpp
+++ b/libgambatte/src/sound/channel4.cpp
@@ -54,7 +54,7 @@ void Channel4::Lfsr::updateBackupCounter(unsigned long const cc) {
 		unsigned long periods = (cc - backupCounter_) / period + 1;
 		backupCounter_ += periods * period;
 
-		if ((master_ || !cgb_) && nr3_ < 0xE * (1u * psg_nr43_s & -psg_nr43_s)) {
+		if (master_ && nr3_ < 0xE * (1u * psg_nr43_s & -psg_nr43_s)) {
 			if (nr3_ & psg_nr43_7biten) {
 				while (periods > 6) {
 					unsigned const xored = (reg_ << 1 ^ reg_) & 0x7E;
@@ -154,7 +154,6 @@ void Channel4::Lfsr::SyncState(NewState *ns) {
 	NSS(reg_);
 	NSS(nr3_);
 	NSS(master_);
-	NSS(cgb_);
 }
 
 Channel4::Channel4()
@@ -221,8 +220,7 @@ void Channel4::reset(unsigned long cc) {
 	setEvent();
 }
 
-void Channel4::init(bool cgb, bool agb) {
-	lfsr_.init(cgb);
+void Channel4::init(bool agb) {
 	envelopeUnit_.init(agb);
 }
 

--- a/libgambatte/src/sound/channel4.h
+++ b/libgambatte/src/sound/channel4.h
@@ -43,7 +43,7 @@ public:
 	void update(uint_least32_t *buf, unsigned long soBaseVol, unsigned long cc, unsigned long end);
 	void reset(unsigned long cc);
 	void resetCc(unsigned long cc, unsigned long newCc) { lfsr_.resetCc(cc, newCc); }
-	void init(bool cgb, bool agb);
+	void init(bool agb);
 	void saveState(SaveState &state, unsigned long cc);
 	void loadState(SaveState const &state);
 	template<bool isReader>void SyncState(NewState *ns);
@@ -60,7 +60,6 @@ private:
 		void nr4Init(unsigned long cc);
 		void reset(unsigned long cc);
 		void resetCc(unsigned long cc, unsigned long newCc);
-		void init(bool cgb) { cgb_ = cgb; }
 		void saveState(SaveState &state, unsigned long cc);
 		void loadState(SaveState const &state);
 		void disableMaster() { killCounter(); master_ = false; reg_ = 0x7FFF; }

--- a/libgambatte/src/video.cpp
+++ b/libgambatte/src/video.cpp
@@ -106,6 +106,7 @@ void LCD::setDmgPalette(unsigned long palette[], unsigned short const dmgColors[
 void LCD::setCgbPalette(unsigned *lut) {
 	for (int i = 0; i < 32768; i++)
 		cgbColorsRgb32_[i] = lut[i];
+
 	refreshPalettes();
 }
 
@@ -944,7 +945,6 @@ void LCD::setDmgPaletteColor(unsigned palNum, unsigned colorNum, unsigned long r
 SYNCFUNC(LCD) {
 	SSS(ppu_);
 	NSS(dmgColorsBgr15_);
-	NSS(cgbColorsRgb32_);
 	NSS(bgpData_);
 	NSS(objpData_);
 	SSS(eventTimes_);

--- a/libgambatte/src/video.cpp
+++ b/libgambatte/src/video.cpp
@@ -127,7 +127,7 @@ LCD::LCD(unsigned char const *oamram, unsigned char const *vram,
 	for (int b = 0; b < 32; b++)
 		for (int g = 0; g < 32; g++)
 			for (int r = 0; r < 32; r++)
-				cgbColorsRgb32_[i++] = ((r * 255 + 15) / 31) | (((g * 255 + 15) / 31) << 8) | (((b * 255 + 15) / 31) << 16) | 255 << 24;
+				cgbColorsRgb32_[i++] = ((b * 255 + 15) / 31) | (((g * 255 + 15) / 31) << 8) | (((r * 255 + 15) / 31) << 16) | 255 << 24;
 
 	std::memset( bgpData_, 0, sizeof  bgpData_);
 	std::memset(objpData_, 0, sizeof objpData_);


### PR DESCRIPTION
Changes needed for SGB sound/borders working in Qt. Also switches the spc to use the C++ interface instead of the C one (functionally the same anyways, should be a performance boost and probably more reliable).