### PR TITLE
Add API For Obtaining ROM & SRAM Bank

### DIFF
--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -374,6 +374,12 @@ public:
 	/** Link cable stuff; never touch for normal operation. */
 	int linkStatus(int which);
 
+	/** Get current ROM bank. */
+	int getRomBank();
+	
+	/** Get current SRAM bank. */
+	int getSramBank();
+
 	/**
 	  * Get reg and flag values.
 	  * @param dest length of at least 10, please

--- a/libgambatte/src/cinterface.cpp
+++ b/libgambatte/src/cinterface.cpp
@@ -231,6 +231,14 @@ GBEXPORT int gambatte_linkstatus(GB *g, int which) {
 	return g->linkStatus(which);
 }
 
+GBEXPORT int gambatte_getrombank(GB *g) {
+	return g->getRomBank();
+}
+
+GBEXPORT int gambatte_getsrambank(GB *g) {
+	return g->getSramBank();
+}
+
 GBEXPORT void gambatte_getregs(GB *g, int *dest) {
 	g->getRegs(dest);
 }

--- a/libgambatte/src/cpu.h
+++ b/libgambatte/src/cpu.h
@@ -146,6 +146,9 @@ public:
 
 	int linkStatus(int which) { return mem_.linkStatus(which); }
 
+	unsigned getRomBank() { return mem_.curRomBank(); }
+	unsigned getSramBank() { return mem_.curSramBank(); }
+
 	void getRegs(int *dest);
 	void setRegs(int *src);
 	void getRtcRegs(unsigned long *dest) { mem_.getRtcRegs(dest, cycleCounter_); }

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -444,6 +444,14 @@ int GB::linkStatus(int which) {
 	return p_->cpu.linkStatus(which);
 }
 
+int GB::getRomBank() {
+	return p_->cpu.getRomBank();
+}
+
+int GB::getSramBank() {
+	return p_->cpu.getSramBank();
+}
+
 void GB::getRegs(int *dest) {
 	p_->cpu.getRegs(dest);
 }

--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -57,7 +57,7 @@ public:
 		return 1;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return 0;
 	}
 
@@ -114,7 +114,7 @@ public:
 		return rombank_;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return rambank_;
 	}
 
@@ -203,7 +203,7 @@ public:
 		return rombank_;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return 0;
 	}
 
@@ -292,7 +292,7 @@ public:
 		return rombank_;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return 0;
 	}
 
@@ -353,7 +353,7 @@ public:
 		return rombank_;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return rambank_;
 	}
 
@@ -459,7 +459,7 @@ public:
 		return rombank_;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return rambank_;
 	}
 
@@ -537,7 +537,7 @@ public:
 		return rombank_;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return rambank_;
 	}
 
@@ -623,7 +623,7 @@ public:
 		return rombank_;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return rambank_;
 	}
 
@@ -723,7 +723,7 @@ public:
 		return rombank_;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return rambank_;
 	}
 
@@ -805,7 +805,7 @@ public:
 		return rombank_;
 	}
 
-	virtual unsigned char curRamBank() const {
+	virtual unsigned char curSramBank() const {
 		return 0;
 	}
 

--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -57,6 +57,10 @@ public:
 		return 1;
 	}
 
+	virtual unsigned char curRamBank() const {
+		return 0;
+	}
+
 	virtual bool disabledRam() const {
 		return !enableRam_;
 	}
@@ -108,6 +112,10 @@ public:
 
 	virtual unsigned char curRomBank() const {
 		return rombank_;
+	}
+
+	virtual unsigned char curRamBank() const {
+		return rambank_;
 	}
 
 	virtual bool disabledRam() const {
@@ -195,6 +203,10 @@ public:
 		return rombank_;
 	}
 
+	virtual unsigned char curRamBank() const {
+		return 0;
+	}
+
 	virtual bool disabledRam() const {
 		return !enableRam_;
 	}
@@ -280,6 +292,10 @@ public:
 		return rombank_;
 	}
 
+	virtual unsigned char curRamBank() const {
+		return 0;
+	}
+
 	virtual bool disabledRam() const {
 		return !enableRam_;
 	}
@@ -335,6 +351,10 @@ public:
 
 	virtual unsigned char curRomBank() const {
 		return rombank_;
+	}
+
+	virtual unsigned char curRamBank() const {
+		return rambank_;
 	}
 
 	virtual bool disabledRam() const {
@@ -439,6 +459,10 @@ public:
 		return rombank_;
 	}
 
+	virtual unsigned char curRamBank() const {
+		return rambank_;
+	}
+
 	virtual bool disabledRam() const {
 		return !enableRam_;
 	}
@@ -511,6 +535,10 @@ public:
 
 	virtual unsigned char curRomBank() const {
 		return rombank_;
+	}
+
+	virtual unsigned char curRamBank() const {
+		return rambank_;
 	}
 
 	virtual bool disabledRam() const {
@@ -593,6 +621,10 @@ public:
 
 	virtual unsigned char curRomBank() const {
 		return rombank_;
+	}
+
+	virtual unsigned char curRamBank() const {
+		return rambank_;
 	}
 
 	virtual bool disabledRam() const {
@@ -691,6 +723,10 @@ public:
 		return rombank_;
 	}
 
+	virtual unsigned char curRamBank() const {
+		return rambank_;
+	}
+
 	virtual bool disabledRam() const {
 		return false;
 	}
@@ -767,6 +803,10 @@ public:
 
 	virtual unsigned char curRomBank() const {
 		return rombank_;
+	}
+
+	virtual unsigned char curRamBank() const {
+		return 0;
 	}
 
 	virtual bool disabledRam() const {

--- a/libgambatte/src/mem/cartridge.h
+++ b/libgambatte/src/mem/cartridge.h
@@ -38,7 +38,7 @@ class Mbc {
 public:
 	virtual ~Mbc() {}
 	virtual unsigned char curRomBank() const = 0;
-	virtual unsigned char curRamBank() const = 0;
+	virtual unsigned char curSramBank() const = 0;
 	virtual bool disabledRam() const = 0;
 	virtual void romWrite(unsigned P, unsigned data, unsigned long cycleCounter) = 0;
 	virtual void saveState(SaveState::Mem &ss) const = 0;
@@ -73,7 +73,7 @@ public:
 	void setWrambank(unsigned bank) { memptrs_.setWrambank(bank); }
 	void setOamDmaSrc(OamDmaSrc oamDmaSrc) { memptrs_.setOamDmaSrc(oamDmaSrc); }
 	unsigned char curRomBank() const { return mbc_->curRomBank(); }
-	unsigned char curRamBank() const { return mbc_->curRamBank(); }
+	unsigned char curSramBank() const { return mbc_->curSramBank(); }
 	bool disabledRam() const { return mbc_->disabledRam(); }
 	void mbcWrite(unsigned addr, unsigned data, unsigned long const cc) { mbc_->romWrite(addr, data, cc); }
 	bool isCgb() const { return gambatte::isCgb(memptrs_); }

--- a/libgambatte/src/mem/cartridge.h
+++ b/libgambatte/src/mem/cartridge.h
@@ -38,6 +38,7 @@ class Mbc {
 public:
 	virtual ~Mbc() {}
 	virtual unsigned char curRomBank() const = 0;
+	virtual unsigned char curRamBank() const = 0;
 	virtual bool disabledRam() const = 0;
 	virtual void romWrite(unsigned P, unsigned data, unsigned long cycleCounter) = 0;
 	virtual void saveState(SaveState::Mem &ss) const = 0;
@@ -72,6 +73,7 @@ public:
 	void setWrambank(unsigned bank) { memptrs_.setWrambank(bank); }
 	void setOamDmaSrc(OamDmaSrc oamDmaSrc) { memptrs_.setOamDmaSrc(oamDmaSrc); }
 	unsigned char curRomBank() const { return mbc_->curRomBank(); }
+	unsigned char curRamBank() const { return mbc_->curRamBank(); }
 	bool disabledRam() const { return mbc_->disabledRam(); }
 	void mbcWrite(unsigned addr, unsigned data, unsigned long const cc) { mbc_->romWrite(addr, data, cc); }
 	bool isCgb() const { return gambatte::isCgb(memptrs_); }

--- a/libgambatte/src/mem/memptrs.cpp
+++ b/libgambatte/src/mem/memptrs.cpp
@@ -82,7 +82,6 @@ MemPtrs::MemPtrs()
 , rambankdata_(0)
 , wramdataend_(0)
 , oamDmaSrc_(oam_dma_src_off)
-, curRomBank_(1)
 , memchunk_len(0)
 {
 }
@@ -125,7 +124,6 @@ void MemPtrs::setRombank0(unsigned bank) {
 }
 
 void MemPtrs::setRombank(unsigned bank) {
-	curRomBank_ = bank;
 	romdata_[1] = romdata() + bank * rombank_size() - mm_rom1_begin;
 	rmem_[0x7] = rmem_[0x6] = rmem_[0x5] = rmem_[0x4] = romdata_[1];
 	disconnectOamDmaAreas();
@@ -236,5 +234,4 @@ SYNCFUNC(MemPtrs) {
 	MSS(rambankdata_);
 	MSS(wramdataend_);
 	NSS(oamDmaSrc_);
-	NSS(curRomBank_);
 }

--- a/libgambatte/src/mem/memptrs.h
+++ b/libgambatte/src/mem/memptrs.h
@@ -96,8 +96,6 @@ private:
 	unsigned char *wramdataend_;
 	OamDmaSrc oamDmaSrc_;
 
-	unsigned curRomBank_;
-
 	int memchunk_len;
 	int memchunk_saveoffs;
 	int memchunk_savelen;

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -42,6 +42,7 @@ public:
 	~Memory();
 	bool loaded() const { return cart_.loaded(); }
 	unsigned curRomBank() const { return cart_.curRomBank(); }
+	unsigned curSramBank() const { return cart_.curRamBank(); }
 	char const * romTitle() const { return cart_.romTitle(); }
 	int peekLY() const { return lcd_.peekLy(); }
 	int getLy(unsigned long const cc) { return nontrivial_ff_read(0x44, cc); }

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -42,7 +42,7 @@ public:
 	~Memory();
 	bool loaded() const { return cart_.loaded(); }
 	unsigned curRomBank() const { return cart_.curRomBank(); }
-	unsigned curSramBank() const { return cart_.curRamBank(); }
+	unsigned curSramBank() const { return cart_.curSramBank(); }
 	char const * romTitle() const { return cart_.romTitle(); }
 	int peekLY() const { return lcd_.peekLy(); }
 	int getLy(unsigned long const cc) { return nontrivial_ff_read(0x44, cc); }


### PR DESCRIPTION
Adds some API so a user can obtain the current ROM/SRAM bank in use (not possible via simple memory reads). Could be fired into BizHawk in some way (probably appending to getRegs, although noting there's no API for setting these, but memory writes can do the job fine there so not really a need).