### PR TITLE
Fix building on MSVC

### DIFF
--- a/libgambatte/src/file/unzip/crypt.h
+++ b/libgambatte/src/file/unzip/crypt.h
@@ -29,10 +29,16 @@
 
 #define CRC32(c, b) ((*(pcrc_32_tab+(((int)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))
 
+#ifdef _MSC_VER
+#define ATTRIBUTE_UNUSED
+#else
+#define ATTRIBUTE_UNUSED __attribute__((unused))
+#endif
+
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab __attribute__((unused)))
+static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab ATTRIBUTE_UNUSED)
 {
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem

--- a/libgambatte/src/file/unzip/crypt.h
+++ b/libgambatte/src/file/unzip/crypt.h
@@ -29,17 +29,12 @@
 
 #define CRC32(c, b) ((*(pcrc_32_tab+(((int)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))
 
-#ifdef _MSC_VER
-#define ATTRIBUTE_UNUSED
-#else
-#define ATTRIBUTE_UNUSED __attribute__((unused))
-#endif
-
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab ATTRIBUTE_UNUSED)
+static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
 {
+    (void)pcrc_32_tab;
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem
                      * with any known compiler so far, though */

--- a/libgambatte/src/file/unzip/ioapi.c
+++ b/libgambatte/src/file/unzip/ioapi.c
@@ -13,7 +13,11 @@
 #include <zlib.h>
 #include "ioapi.h"
 
-
+#ifdef _MSC_VER
+#define ATTRIBUTE_UNUSED
+#else
+#define ATTRIBUTE_UNUSED __attribute__((unused))
+#endif
 
 /* I've found an old Unix (a SunOS 4.1.3_U1) without all SEEK_* defined.... */
 
@@ -66,7 +70,7 @@ int ZCALLBACK ferror_file_func OF((
 
 
 voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
-   voidpf opaque __attribute__((unused));
+   voidpf opaque ATTRIBUTE_UNUSED;
    const char* filename;
    int mode;
 {
@@ -88,7 +92,7 @@ voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
 
 
 uLong ZCALLBACK fread_file_func (opaque, stream, buf, size)
-   voidpf opaque __attribute__((unused));
+   voidpf opaque ATTRIBUTE_UNUSED;
    voidpf stream;
    void* buf;
    uLong size;
@@ -100,7 +104,7 @@ uLong ZCALLBACK fread_file_func (opaque, stream, buf, size)
 
 
 uLong ZCALLBACK fwrite_file_func (opaque, stream, buf, size)
-   voidpf opaque __attribute__((unused));
+   voidpf opaque ATTRIBUTE_UNUSED;
    voidpf stream;
    const void* buf;
    uLong size;
@@ -111,7 +115,7 @@ uLong ZCALLBACK fwrite_file_func (opaque, stream, buf, size)
 }
 
 long ZCALLBACK ftell_file_func (opaque, stream)
-   voidpf opaque __attribute__((unused));
+   voidpf opaque ATTRIBUTE_UNUSED;
    voidpf stream;
 {
     long ret;
@@ -120,7 +124,7 @@ long ZCALLBACK ftell_file_func (opaque, stream)
 }
 
 long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
-   voidpf opaque __attribute__((unused));
+   voidpf opaque ATTRIBUTE_UNUSED;
    voidpf stream;
    uLong offset;
    int origin;
@@ -146,7 +150,7 @@ long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
 }
 
 int ZCALLBACK fclose_file_func (opaque, stream)
-   voidpf opaque __attribute__((unused));
+   voidpf opaque ATTRIBUTE_UNUSED;
    voidpf stream;
 {
     int ret;
@@ -155,7 +159,7 @@ int ZCALLBACK fclose_file_func (opaque, stream)
 }
 
 int ZCALLBACK ferror_file_func (opaque, stream)
-   voidpf opaque __attribute__((unused));
+   voidpf opaque ATTRIBUTE_UNUSED;
    voidpf stream;
 {
     int ret;

--- a/libgambatte/src/file/unzip/ioapi.c
+++ b/libgambatte/src/file/unzip/ioapi.c
@@ -13,12 +13,6 @@
 #include <zlib.h>
 #include "ioapi.h"
 
-#ifdef _MSC_VER
-#define ATTRIBUTE_UNUSED
-#else
-#define ATTRIBUTE_UNUSED __attribute__((unused))
-#endif
-
 /* I've found an old Unix (a SunOS 4.1.3_U1) without all SEEK_* defined.... */
 
 #ifndef SEEK_CUR
@@ -69,11 +63,9 @@ int ZCALLBACK ferror_file_func OF((
    voidpf stream));
 
 
-voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
-   voidpf opaque ATTRIBUTE_UNUSED;
-   const char* filename;
-   int mode;
+voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, int mode)
 {
+    (void)opaque;
     FILE* file = NULL;
     const char* mode_fopen = NULL;
     if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
@@ -91,44 +83,34 @@ voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
 }
 
 
-uLong ZCALLBACK fread_file_func (opaque, stream, buf, size)
-   voidpf opaque ATTRIBUTE_UNUSED;
-   voidpf stream;
-   void* buf;
-   uLong size;
+uLong ZCALLBACK fread_file_func (voidpf opaque, voidpf stream, void* buf, uLong size)
 {
+    (void)opaque;
     uLong ret;
     ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
     return ret;
 }
 
 
-uLong ZCALLBACK fwrite_file_func (opaque, stream, buf, size)
-   voidpf opaque ATTRIBUTE_UNUSED;
-   voidpf stream;
-   const void* buf;
-   uLong size;
+uLong ZCALLBACK fwrite_file_func (voidpf opaque, voidpf stream, const void* buf, uLong size)
 {
+    (void)opaque;
     uLong ret;
     ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
     return ret;
 }
 
-long ZCALLBACK ftell_file_func (opaque, stream)
-   voidpf opaque ATTRIBUTE_UNUSED;
-   voidpf stream;
+long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
 {
+    (void)opaque;
     long ret;
     ret = ftell((FILE *)stream);
     return ret;
 }
 
-long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
-   voidpf opaque ATTRIBUTE_UNUSED;
-   voidpf stream;
-   uLong offset;
-   int origin;
+long ZCALLBACK fseek_file_func (voidpf opaque, voidpf stream, uLong offset, int origin)
 {
+    (void)opaque;
     int fseek_origin=0;
     long ret;
     switch (origin)
@@ -149,26 +131,23 @@ long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
     return ret;
 }
 
-int ZCALLBACK fclose_file_func (opaque, stream)
-   voidpf opaque ATTRIBUTE_UNUSED;
-   voidpf stream;
+int ZCALLBACK fclose_file_func (voidpf opaque, voidpf stream)
 {
+    (void)opaque;
     int ret;
     ret = fclose((FILE *)stream);
     return ret;
 }
 
-int ZCALLBACK ferror_file_func (opaque, stream)
-   voidpf opaque ATTRIBUTE_UNUSED;
-   voidpf stream;
+int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
 {
+    (void)opaque;
     int ret;
     ret = ferror((FILE *)stream);
     return ret;
 }
 
-void fill_fopen_filefunc (pzlib_filefunc_def)
-  zlib_filefunc_def* pzlib_filefunc_def;
+void fill_fopen_filefunc (zlib_filefunc_def* pzlib_filefunc_def)
 {
     pzlib_filefunc_def->zopen_file = fopen_file_func;
     pzlib_filefunc_def->zread_file = fread_file_func;

--- a/libgambatte/src/statesaver.cpp
+++ b/libgambatte/src/statesaver.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <fstream>
 #include <functional>
+#include <memory>
 #include <sstream>
 #include <vector>
 #include <cstring>
@@ -550,11 +551,10 @@ bool StateSaver::saveState(SaveState const &state,
 		return false;
 
 	std::size_t size = saveState(state, videoBuf, pitch, NULL, mode);
-	std::string stateBuf;
-	stateBuf.reserve(size);
+	std::unique_ptr<char[]> stateBuf {new char[size]};
 
-	saveState(state, videoBuf, pitch, stateBuf.data(), mode);
-	file << stateBuf;
+	saveState(state, videoBuf, pitch, stateBuf.get(), mode);
+	file.write(stateBuf.get(), size);
 
 	return !file.fail();
 }

--- a/libgambatte/src/statesaver.cpp
+++ b/libgambatte/src/statesaver.cpp
@@ -550,10 +550,11 @@ bool StateSaver::saveState(SaveState const &state,
 		return false;
 
 	std::size_t size = saveState(state, videoBuf, pitch, NULL, mode);
-	char stateBuf[size];
+	std::string stateBuf;
+	stateBuf.reserve(size);
 
-	saveState(state, videoBuf, pitch, stateBuf, mode);
-	file.write(stateBuf, size);
+	saveState(state, videoBuf, pitch, stateBuf.data(), mode);
+	file << stateBuf;
 
 	return !file.fail();
 }


### PR DESCRIPTION
While working on #19, I noticed building on MSVC due to the following problems:

- `__attribute__((unused))` does not exist, this is only used in some files from `unzip`.
- VLAs are not supported, this is used once in `statesaver.cpp:553`.

For the `__attribute__` issue, I just added a simple check for MSVC:
```cpp
#ifdef _MSC_VER
#define ATTRIBUTE_UNUSED
#else
#define ATTRIBUTE_UNUSED __attribute__((unused))
#endif
```

For the VLA, I simply replaced it with a `std::string` as it provides a convenient way to replicate the behaviour.