### PR TITLE
Use fixed width data type in crc32 calculation

### DIFF
--- a/libgambatte/src/file/crc32.cpp
+++ b/libgambatte/src/file/crc32.cpp
@@ -46,7 +46,7 @@
 
 namespace gambatte {
 
-static unsigned long CRC32Table[256] = {
+static gambatte::uint_least32_t CRC32Table[256] = {
 	0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
 	0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91,
 	0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE,	0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7,
@@ -81,7 +81,7 @@ static unsigned long CRC32Table[256] = {
 	0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D,
 };
 
-unsigned long crc32(unsigned long crc, void const *buf, std::size_t size) {
+gambatte::uint_least32_t crc32(gambatte::uint_least32_t crc, void const *buf, std::size_t size) {
 	if (size <= 0)
 		return crc;
 

--- a/libgambatte/src/file/crc32.h
+++ b/libgambatte/src/file/crc32.h
@@ -6,10 +6,11 @@
 #else
 
 #include <cstring>
+#include "gbint.h"
 
 namespace gambatte {
 
-unsigned long crc32(unsigned long crc, void const *buf, std::size_t size);
+gambatte::uint_least32_t crc32(gambatte::uint_least32_t crc, void const *buf, std::size_t size);
 
 }
 


### PR DESCRIPTION
Due to differences in compilers, the crc32 calculation in the no-libz-path may output different results.
The cause for this phenomenon, is that the data type `unsigned long` may be of different size depending on the compiler. An example of this occuring, and its consequences can be seen here: https://godbolt.org/z/x1bcGW9n6

This PR attempts to fix the issue by using a fixed 32-bit width data type instead.